### PR TITLE
Fix resize of main window on password dialog

### DIFF
--- a/xul-ext/chrome/content/commonDialog.js
+++ b/xul-ext/chrome/content/commonDialog.js
@@ -649,7 +649,6 @@ var keeFoxDialogManager = {
             // set "no passwords" message
             document.getElementById("keefox-autoauth-description")
                 .setAttribute("value", keefox_org.locale.$STR("httpAuth.noMatches"));
-            window.sizeToContent();
             return;
         }        
         
@@ -776,8 +775,6 @@ var keeFoxDialogManager = {
                 box.removeChild(box.childNodes[0]);
             }
             box.appendChild(list);
-
-            window.sizeToContent();
         }
 
         if (matchedLogins[bestMatch] === undefined)


### PR DESCRIPTION
Fixes #8.

With KeeBird 1.0.1, the main ThunderBird window loses maximized status and grows in size every time a password prompt is shown. This fix resolves the issue. Tested in Windows with latest stable ThunderBird 52.8.0.