### PR TITLE
working login in thunderbird 60; settings interface broken

### DIFF
--- a/xul-ext/chrome/content/install.js
+++ b/xul-ext/chrome/content/install.js
@@ -22,6 +22,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 "use strict";
 
+let Cu = Components.utils;
+
+Cu.import("resource://gre/modules/FileUtils.jsm")
+
 var KF_KPZIP_DOWNLOAD_PATH = "https://downloads.sourceforge.net/project/keepass/KeePass%202.x/2.35/";
 var KF_KPZIP_FILE_NAME = "KeePass-2.35.zip?r=&ts=";
 var KF_KPZIP_SAVE_NAME = "KeePass-2.35.zip";
@@ -397,9 +401,7 @@ function IC1setupKP(mainWindow)
             }            
             showSection('IC1setupKPdownloaded');
             
-            var file = Components.classes["@mozilla.org/file/local;1"]
-            .createInstance(Components.interfaces.nsILocalFile);
-            file.initWithFile(mainWindow.keefox_org.utils.myProfileDir());
+            var file = new FileUtils.File(mainWindow.keefox_org.utils.myProfileDir());
             file.append(KF_KP_SAVE_NAME);            
 
             installState |= KF_INSTALL_STATE_KP_EXECUTING;
@@ -456,9 +458,7 @@ function IC1setupNET(mainWindow)
             
             installState |= KF_INSTALL_STATE_NET_EXECUTING;
 
-            var file = Components.classes["@mozilla.org/file/local;1"]
-            .createInstance(Components.interfaces.nsILocalFile);
-            file.initWithFile(mainWindow.keefox_org.utils.myProfileDir());
+            var file = new FileUtils.File(mainWindow.keefox_org.utils.myProfileDir());
             file.append(KF_NET_FILE_NAME);
                                 
             mainWindow.keefox_org.runAnInstaller(file.path,"", 
@@ -569,9 +569,7 @@ function IC2setupKP(mainWindow)
 
             installState |= KF_INSTALL_STATE_KP_EXECUTING;
 
-            var file = Components.classes["@mozilla.org/file/local;1"]
-            .createInstance(Components.interfaces.nsILocalFile);
-            file.initWithFile(mainWindow.keefox_org.utils.myProfileDir());
+            var file = new FileUtils.File(mainWindow.keefox_org.utils.myProfileDir());
             file.append(KF_KP_SAVE_NAME);
             
             mainWindow.keefox_org.runAnInstaller(file.path,"/silent",
@@ -619,9 +617,7 @@ function IC2setupCustomKP(mainWindow)
 
             installState |= KF_INSTALL_STATE_KP_EXECUTING;
 
-            var file = Components.classes["@mozilla.org/file/local;1"]
-            .createInstance(Components.interfaces.nsILocalFile);
-            file.initWithFile(mainWindow.keefox_org.utils.myProfileDir());
+            var file = new FileUtils.File(mainWindow.keefox_org.utils.myProfileDir());
             file.append(KF_KP_SAVE_NAME);
             
             mainWindow.keefox_org.runAnInstaller(file.path,"",
@@ -1040,14 +1036,10 @@ function copyKeePassRPCFilesTo(keePassLocation)
 
 function runKeePassRPCExecutableInstaller(keePassLocation)
 {
-    var destFolder = Components.classes["@mozilla.org/file/local;1"]
-    .createInstance(Components.interfaces.nsILocalFile);
-    destFolder.initWithPath(keePassLocation);
+    var destFolder = new FileUtils.File(keePassLocation);
     destFolder.append("plugins");
     
-    var file = Components.classes["@mozilla.org/file/local;1"]
-        .createInstance(Components.interfaces.nsILocalFile);
-        file.initWithPath(mainWindow.keefox_org.utils.myDepsDir());
+    var file = new FileUtils.File(mainWindow.keefox_org.utils.myDepsDir());
         file.append(KF_KRPC_FILE_NAME);
 
     mainWindow.keefox_org.runAnInstaller(file.path, '"'
@@ -1061,9 +1053,7 @@ function runKeePassRPCExecutableInstaller(keePassLocation)
 // TODO:2: ... or not, if FF4 has removed the required features!
 function extractKPZip (zipFilePath, storeLocation)
 {
-    var zipFile = Components.classes["@mozilla.org/file/local;1"]
-        .createInstance(Components.interfaces.nsILocalFile);
-        zipFile.initWithFile(mainWindow.keefox_org.utils.myProfileDir());
+    var zipFile = new FileUtils.File(mainWindow.keefox_org.utils.myProfileDir());
 
         zipFile.append(zipFilePath);
         
@@ -1085,7 +1075,7 @@ function extractKPZip (zipFilePath, storeLocation)
         {
             try
             {
-                target.create(Components.interfaces.nsILocalFile.DIRECTORY_TYPE, 484);
+                target.create(Components.interfaces.nsIFile.DIRECTORY_TYPE, 484);
             }
             catch (e)
             {
@@ -1108,7 +1098,7 @@ function extractKPZip (zipFilePath, storeLocation)
 
         try
         {
-            target.create(Components.interfaces.nsILocalFile.NORMAL_FILE_TYPE, 484);
+            target.create(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 484);
             //TODO:2: different permissions for special files on linux. e.g. 755
             // for main executable? not sure how it works with Mono though
             // so needs much more reading...

--- a/xul-ext/install.rdf
+++ b/xul-ext/install.rdf
@@ -20,7 +20,7 @@
         <!-- Thunderbird -->
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
         <em:minVersion>32.0</em:minVersion>
-        <em:maxVersion>56.*</em:maxVersion>
+        <em:maxVersion>60.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 

--- a/xul-ext/modules/FAMS.js
+++ b/xul-ext/modules/FAMS.js
@@ -609,9 +609,7 @@ FirefoxAddonMessageService.prototype.setConfiguration = function (configuration)
         throw new Exception("Trying to save a configuration with a different ID from the currently initialised config. Failed.");
 
     this.configuration = configuration;
-    var str = Cc["@mozilla.org/supports-string;1"].createInstance(Ci.nsISupportsString);
-    str.data = JSON.stringify(configuration);
-    this.prefBranch.setComplexValue("config.utf8." + configuration.id, Ci.nsISupportsString, str);
+    this.prefBranch.setStringPref("config.utf8." + configuration.id, JSON.stringify(configuration));
 };
 
 // Use the current configuration stored in preferences unless it has not yet been defined
@@ -624,13 +622,11 @@ FirefoxAddonMessageService.prototype.getConfiguration = function ()
         var prefType = this.prefBranch.getPrefType("config." + this.configId);
         if (prefType == 32)
         {
-            var str = Cc["@mozilla.org/supports-string;1"].createInstance(Ci.nsISupportsString);
-            str.data = this.prefBranch.getCharPref("config." + this.configId);
-            this.prefBranch.setComplexValue("config.utf8." + this.configId, Ci.nsISupportsString, str);
+            this.prefBranch.setStringPref("config.utf8." + this.configId, this.prefBranch.getCharPref("config." + this.configId));
             this.prefBranch.clearUserPref("config." + this.configId);
         }
 
-        var prefData = this.prefBranch.getComplexValue("config.utf8." + this.configId, Ci.nsISupportsString).data;
+        var prefData = this.prefBranch.getStringPref("config.utf8." + this.configId);
         var conf = JSON.parse(prefData);
         if (conf.version < this.defaultConfiguration.version)
         {

--- a/xul-ext/modules/KF.js
+++ b/xul-ext/modules/KF.js
@@ -43,6 +43,7 @@ Cu.import("resource://kfmod/TutorialHelper.js");
 Cu.import("resource://kfmod/SampleChecker.js");
 Cu.import("resource://kfmod/DataMigration.js");
 Cu.import("resource://gre/modules/Timer.jsm");
+Cu.import("resource://gre/modules/FileUtils.jsm");
 
 // constructor
 function KeeFox()
@@ -566,8 +567,7 @@ KeeFox.prototype = {
             args.push('' + mruparam + '');
         }
 
-        var file = Components.classes["@mozilla.org/file/local;1"]
-                   .createInstance(Components.interfaces.nsILocalFile);
+        var file = null;
         if (fileNameIsRelative) {
             var ffDir = Components.classes["@mozilla.org/file/directory_service;1"]
                         .getService(Components.interfaces.nsIProperties)
@@ -576,11 +576,13 @@ KeeFox.prototype = {
             // "installation location" so this is the best we can do
             if (ffDir.leafName == "browser")
                 ffDir = ffDir.parent;
-
-            file.setRelativeDescriptor(ffDir, fileName);
+            //TODO: possible broken with TB 60. append does not accept path seperators
+            //file.setRelativeDescriptor(ffDir, fileName);
+            file = new FileUtils.File(ffDir);
+            file.append(fileName);
         } else
         {
-            file.initWithPath(fileName);
+            file = new FileUtils.File(fileName);
         }
 
         this._KFLog.info("About to execute: " + file.path + " " + args.join(' '));
@@ -596,9 +598,7 @@ KeeFox.prototype = {
     runAnInstaller: function (fileName, params, callback)
     {
         var args = [fileName, params];                
-        var file = Components.classes["@mozilla.org/file/local;1"]
-                   .createInstance(Components.interfaces.nsILocalFile);
-        file.initWithPath(this.utils.myDepsDir() + "\\KeeFoxElevate.exe");
+        var file = new FileUtils.File(this.utils.myDepsDir() + "\\KeeFoxElevate.exe");
 
         var process = Components.classes["@mozilla.org/process/util;1"]
                       .createInstance(Components.interfaces.nsIProcess2 || Components.interfaces.nsIProcess);

--- a/xul-ext/modules/KFExtension.js
+++ b/xul-ext/modules/KFExtension.js
@@ -25,6 +25,7 @@ let Ci = Components.interfaces;
 let Cu = Components.utils;
 
 var EXPORTED_SYMBOLS = ["KFExtension"];
+Cu.import("resource://gre/modules/FileUtils.jsm");
 
 // constructor
 function KFE()
@@ -36,9 +37,7 @@ function KFE()
                     getService(Components.interfaces.nsIProperties);
         var dir = directoryService.get("ProfD", Components.interfaces.nsIFile);
     
-        var folder = Components.classes["@mozilla.org/file/local;1"]
-            .createInstance(Components.interfaces.nsILocalFile);
-        folder.initWithPath(dir.path);
+        var folder = new FileUtils.File(dir.path);
         folder.append("keefox");
 
         if (!folder.exists())
@@ -97,7 +96,7 @@ function KFE()
     };
     this.prefs._getStringValue = function(name)
     {
-        try { return this._prefBranch.getComplexValue(name, Components.interfaces.nsISupportsString).data;
+        try { return this._prefBranch.getStringPref(name);
         } catch (ex) { return null; }
     };
     this.prefs._getIntValue = function(name)
@@ -122,11 +121,7 @@ function KFE()
     this.prefs._setStringValue = function(name, value)
     {
         try { 
-            var str = Components.classes["@mozilla.org/supports-string;1"]
-                .createInstance(Components.interfaces.nsISupportsString);
-            str.data = value;
-            this._prefBranch.setComplexValue(name, 
-                Components.interfaces.nsISupportsString, str);
+            this._prefBranch.setStringPref(name, value);
         } catch (ex) {}
     };
     this.prefs._setIntValue = function(name, value)

--- a/xul-ext/modules/KFLogger.js
+++ b/xul-ext/modules/KFLogger.js
@@ -46,6 +46,7 @@ let Ci = Components.interfaces;
 let Cu = Components.utils;
 
 var EXPORTED_SYMBOLS = ["KeeFoxLog"];
+Cu.import("resource://gre/modules/FileUtils.jsm");
 
 // constructor
 function KeeFoxLogger()
@@ -99,18 +100,13 @@ KeeFoxLogger.prototype = {
                 getService(Components.interfaces.nsIProperties);
             var dir = directoryService.get("ProfD", Components.interfaces.nsIFile);
             
-            var folder = Components.classes["@mozilla.org/file/local;1"]
-                .createInstance(Components.interfaces.nsILocalFile);
-            folder.initWithPath(dir.path);
+            var folder = new FileUtils.File(dir.path);
             folder.append("keefox");
         
             if (!folder.exists())
                 folder.create(folder.DIRECTORY_TYPE, parseInt("0775", 8));
                 
-            var file = Components.classes["@mozilla.org/file/local;1"]
-                .createInstance(Components.interfaces.nsILocalFile);
-
-            file.initWithPath(dir.path);
+            var file = new FileUtils.File(dir.path);
             file.append("keefox");
             file.append("log.txt");
             this.__logFile = file;

--- a/xul-ext/modules/commands.js
+++ b/xul-ext/modules/commands.js
@@ -725,7 +725,7 @@ function commandManager () {
 
         try
         {
-            var prefData = prefBranch.getComplexValue("commands", Ci.nsISupportsString).data;
+            var prefData = prefBranch.getStringPref("commands");
             var coms = JSON.parse(prefData);
             var currentVersion = prefBranch.getIntPref("commandsVersion");
             // Backwards migrations are not supported
@@ -747,9 +747,7 @@ function commandManager () {
         var prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
         var prefBranch = prefService.getBranch("extensions.keefox@chris.tomlinson.");
 
-        var str = Cc["@mozilla.org/supports-string;1"].createInstance(Ci.nsISupportsString);
-        str.data = JSON.stringify(this.commands);
-        prefBranch.setComplexValue("commands", Ci.nsISupportsString, str);
+        prefBranch.setStringPref("commands", JSON.stringify(this.commands));
         
         prefBranch.setIntPref("commandsVersion",this.commandsConfigVersion);
     };

--- a/xul-ext/modules/config.js
+++ b/xul-ext/modules/config.js
@@ -246,7 +246,7 @@ function config()
 
         try
         {
-            var prefData = prefBranch.getComplexValue("config", Ci.nsISupportsString).data;
+            var prefData = prefBranch.getStringPref("config");
             var conf = JSON.parse(prefData);
             //TODO:2: In future check version here and apply migrations if needed
             //var currentVersion = prefBranch.getIntPref("configVersion");
@@ -265,9 +265,7 @@ function config()
         var prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
         var prefBranch = prefService.getBranch("extensions.keefox@chris.tomlinson.");
 
-        var str = Cc["@mozilla.org/supports-string;1"].createInstance(Ci.nsISupportsString);
-        str.data = JSON.stringify(this.current);
-        prefBranch.setComplexValue("config", Ci.nsISupportsString, str);
+        prefBranch.setStringPref("config", JSON.stringify(this.current));
 
         //TODO:1.6: Stop forcing this to 1 when we release the first new version
         prefBranch.setIntPref("configVersion",1);

--- a/xul-ext/modules/kprpcClient.js
+++ b/xul-ext/modules/kprpcClient.js
@@ -38,7 +38,6 @@ scriptLoader.loadSubScript("resource://kfmod/sjcl.js");
 Cu.import("resource://kfmod/utils.js");
 Cu.import("resource://kfmod/SRP.js");
 Cu.import("resource://gre/modules/Timer.jsm");
-Cu.import("resource://gre/modules/ISO8601DateUtils.jsm");
 
 Cu.import("resource://kfmod/session.js");
 
@@ -639,7 +638,7 @@ kprpcClient.prototype.constructor = kprpcClient;
   	        window.keefox_win.Logger.info("Setting KeePassRPC location to " + currentLocation + ".");
   	        window.keefox_org.changeLocation(currentLocation);
   	    }
-  	    window.keefox_org._keeFoxExtension.prefs.setValue("lastConnectedToKeePass", ISO8601DateUtils.create(new Date()));
+  	    window.keefox_org._keeFoxExtension.prefs.setValue("lastConnectedToKeePass", new Date());
   	    window.keefox_org._refreshKPDB();
   	    window.keefox_org.getApplicationMetadata();
   	};

--- a/xul-ext/modules/locales.js
+++ b/xul-ext/modules/locales.js
@@ -416,7 +416,7 @@ Localisation.prototype = {
     {
         var prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
         var prefBranchRoot = prefService.getBranch("");
-        return prefBranchRoot.getComplexValue("general.useragent.locale", Ci.nsISupportsString).data.toLowerCase();
+        return prefBranchRoot.getStringPref("general.useragent.locale").toLowerCase();
     }
 
 };

--- a/xul-ext/modules/utils.js
+++ b/xul-ext/modules/utils.js
@@ -26,6 +26,7 @@ var EXPORTED_SYMBOLS = ["utils"];
 Cu.import("resource://kfmod/KFLogger.js");
 Cu.import("resource://kfmod/KFExtension.js");
 Cu.import("resource://kfmod/biginteger.js");
+Cu.import("resource://gre/modules/FileUtils.jsm");
 
 // constructor
 function Utils()
@@ -196,9 +197,7 @@ Utils.prototype = {
                 
                 try
                 {
-                    var defaultFolder = Components.classes["@mozilla.org/file/local;1"]
-                        .createInstance(Components.interfaces.nsILocalFile);
-                    defaultFolder.initWithPath(KFExtension.prefs.getValue("keePassInstalledLocation","not installed"));
+                    var defaultFolder = new FileUtils.File(KFExtension.prefs.getValue("keePassInstalledLocation","not installed"));
                     defaultFolder.append("plugins");
 
                     if (keePassRPCLocation == defaultFolder.path || keePassRPCLocation.slice(0,-1) == defaultFolder.path)
@@ -221,9 +220,7 @@ Utils.prototype = {
         {
             keePassLocation = KFExtension.prefs.getValue("keePassInstalledLocation","not installed");
 
-            var folder = Components.classes["@mozilla.org/file/local;1"]
-                        .createInstance(Components.interfaces.nsILocalFile);
-            folder.initWithPath(keePassLocation);
+            var folder = new FileUtils.File(keePassLocation);
             folder.append("plugins");
             keePassRPCLocation = folder.path;
             if (this._KFLog.logSensitiveData)
@@ -244,11 +241,9 @@ Utils.prototype = {
         else
             this._KFLog.debug("Looking for the KeePass EXE.");
 
-        var file = Components.classes["@mozilla.org/file/local;1"]
-                    .createInstance(Components.interfaces.nsILocalFile);
         try
         {
-            file.initWithPath(keePassLocation);
+            var file = new FileUtils.File(keePassLocation);
             if (file.isDirectory())
             {
                 file.append("KeePass.exe");
@@ -274,12 +269,11 @@ Utils.prototype = {
             this._KFLog.info("Looking for the KeePassRPC plugin plgx in " + keePassRPCLocation + " and " + keePassLocation);
         else
             this._KFLog.info("Looking for the KeePassRPC plugin plgx");
-
-        var file = Components.classes["@mozilla.org/file/local;1"]
-                    .createInstance(Components.interfaces.nsILocalFile);
+        
+        var file = null;
         try
         {
-            file.initWithPath(keePassRPCLocation);
+            file = new FileUtils.File(keePassRPCLocation);
             if (file.isDirectory())
             {
                 file.append("KeePassRPC.plgx");
@@ -299,7 +293,7 @@ Utils.prototype = {
         {
             try
             {
-                file.initWithPath(keePassLocation);
+                file = new FileUtils.File(keePassLocation);
                 if (file.isDirectory())
                 {
                     file.append("KeePassRPC.plgx");
@@ -323,9 +317,7 @@ Utils.prototype = {
             // (where a DLL is used rather than PLGX)
             if (!KeePassRPCfound)
             {
-                file = Components.classes["@mozilla.org/file/local;1"].
-                    createInstance(Components.interfaces.nsILocalFile)
-                file.initWithPath(keePassRPCLocation);
+                file = new FileUtils.File(keePassRPCLocation);
                 if (file.isDirectory())
                 {
                     file.append("KeePassRPC.dll");
@@ -360,9 +352,7 @@ Utils.prototype = {
         
         if (monoLocation == "not installed")
         {
-            var mono_exec = Components.classes["@mozilla.org/file/local;1"]
-                             .createInstance(Components.interfaces.nsILocalFile);
-            mono_exec.initWithPath(defaultMonoExec);
+            var mono_exec =  new FileUtils.File(defaultMonoExec);
             if (mono_exec.exists())
             {
                 monoLocation = mono_exec.path;            
@@ -384,11 +374,9 @@ Utils.prototype = {
 
         this._KFLog.debug("Looking for the Mono executable in " + monoLocation);
 
-        var file = Components.classes["@mozilla.org/file/local;1"]
-                    .createInstance(Components.interfaces.nsILocalFile);
         try
         {
-            file.initWithPath(monoLocation);
+            var file = new FileUtils.File(monoLocation);
             if (file.isFile())
             {
                 monoExecFound = true;
@@ -409,9 +397,7 @@ Utils.prototype = {
     
     IsUserAdministrator: function()
     {
-        var file = Components.classes["@mozilla.org/file/local;1"]
-                   .createInstance(Components.interfaces.nsILocalFile);
-        file.initWithPath(this.myDepsDir() + "\\CheckForAdminRights.exe");
+        var file = new FileUtils.File(this.myDepsDir() + "\\CheckForAdminRights.exe");
 
         var process = Components.classes["@mozilla.org/process/util;1"]
                       .createInstance(Components.interfaces.nsIProcess);
@@ -455,7 +441,8 @@ Utils.prototype = {
                     if (url == currentBrowser.currentURI.spec)
                     {
                         // The URL is already opened. Select this tab.
-                        tabbrowser.selectedTab = tabbrowser.tabContainer.childNodes[index];
+                        //TODO: tabcontainer may needs to be exchanged for tabmail-tabs (TB59)
+                        tabbrowser.selectedTab = tabbrowser.tabcontainer.childNodes[index];
 
                         // Focus *this* browser-window
                         browserWin.focus();
@@ -495,9 +482,7 @@ Utils.prototype = {
     
     myDepsDir: function()
     {
-        var file = Components.classes["@mozilla.org/file/local;1"]
-        .createInstance(Components.interfaces.nsILocalFile);
-        file.initWithPath(this.myInstalledDir());
+        var file = new FileUtils.File(this.myInstalledDir());
         file.append("deps");
         return file.path;
     },
@@ -527,9 +512,7 @@ Utils.prototype = {
                     getService(Components.interfaces.nsIProperties);
         var dir = directoryService.get("ProfD", Components.interfaces.nsIFile);
     
-        var folder = Components.classes["@mozilla.org/file/local;1"]
-            .createInstance(Components.interfaces.nsILocalFile);
-        folder.initWithPath(dir.path);
+        var folder = new FileUtils.File(dir.path);
         folder.append("keefox");
 
         if (!folder.exists())


### PR DESCRIPTION
The PR fixes the login interface for Thunderbird 60.
It is possible to login with existing setting from before the update to Thunderbird 60 and update to the keebird addon version.

Only problem is that somehow the settings values can't be shown and you have to close the settings menu with ALT+F4